### PR TITLE
Add wildcard subscription support

### DIFF
--- a/lib/socket_can.ex
+++ b/lib/socket_can.ex
@@ -15,8 +15,35 @@ defmodule SocketCAN do
     end
   end
 
+  @doc """
+  Subscribe the calling process to receive frames with a specific ID.
+
+  ## Examples
+
+      SocketCAN.subscribe(MyCANBus, 0x123)
+  """
   def subscribe(socket_can, frame_id) do
-    Registry.register(socket_can, frame_id, nil)
-    :ok
+    case Registry.register(socket_can, frame_id, nil) do
+      {:ok, _} -> :ok
+      {:error, {:already_registered, _}} -> :ok
+    end
+  end
+
+  @doc """
+  Subscribe the calling process to receive all CAN frames.
+
+  ## Examples
+
+      SocketCAN.subscribe(MyCANBus)
+      
+      receive do
+        {:can_frame, frame} -> IO.inspect(frame)
+      end
+  """
+  def subscribe(socket_can) do
+    case Registry.register(socket_can, :all_frames, nil) do
+      {:ok, _} -> :ok
+      {:error, {:already_registered, _}} -> :ok
+    end
   end
 end

--- a/test/socket_can/reader_test.exs
+++ b/test/socket_can/reader_test.exs
@@ -1,0 +1,149 @@
+defmodule SocketCAN.ReaderTest do
+  use ExUnit.Case
+
+  alias SocketCAN.Frame
+
+  describe "frame dispatching with wildcard subscribers" do
+    setup do
+      registry_name = :"test_registry_#{System.unique_integer()}"
+      {:ok, _} = Registry.start_link(keys: :duplicate, name: registry_name)
+      {:ok, registry: registry_name}
+    end
+
+    test "Reader dispatches frames to both specific and wildcard subscribers", %{
+      registry: registry
+    } do
+      # Mock socket module for testing
+      _parent = self()
+
+      # Create a test reader state
+      reader_state = %{
+        socket: :mock_socket,
+        interface: "test0",
+        registry: registry,
+        recv_timeout: 100
+      }
+
+      # Subscribe to all frames from test process
+      SocketCAN.subscribe(registry)
+
+      # Also subscribe to specific frame ID
+      SocketCAN.subscribe(registry, 0x123)
+
+      # Create test frame
+      test_frame = %Frame{
+        id: 0x123,
+        data: <<1, 2, 3, 4>>,
+        is_extended?: false,
+        frame_type: :data,
+        timestamp: 123_456
+      }
+
+      # Simulate what Reader does when receiving a frame
+      # Dispatch to ID-specific subscribers
+      Registry.dispatch(reader_state.registry, test_frame.id, fn entries ->
+        for {pid, _value} <- entries do
+          send(pid, {:can_frame, test_frame})
+        end
+      end)
+
+      # Dispatch to wildcard subscribers
+      Registry.dispatch(reader_state.registry, :all_frames, fn entries ->
+        for {pid, _value} <- entries do
+          send(pid, {:can_frame, test_frame})
+        end
+      end)
+
+      # Should receive the frame twice (once from specific, once from wildcard)
+      assert_receive {:can_frame, ^test_frame}
+      assert_receive {:can_frame, ^test_frame}
+      refute_receive {:can_frame, _}, 100
+    end
+
+    test "wildcard subscriber receives frames with different IDs", %{registry: registry} do
+      # Subscribe to all frames
+      SocketCAN.subscribe(registry)
+
+      frames = [
+        %Frame{id: 0x100, data: <<1>>, is_extended?: false, frame_type: :data},
+        %Frame{id: 0x200, data: <<2>>, is_extended?: false, frame_type: :data},
+        %Frame{id: 0x300, data: <<3>>, is_extended?: false, frame_type: :data}
+      ]
+
+      # Dispatch each frame as Reader would
+      for frame <- frames do
+        Registry.dispatch(registry, :all_frames, fn entries ->
+          for {pid, _value} <- entries do
+            send(pid, {:can_frame, frame})
+          end
+        end)
+      end
+
+      # Should receive all frames
+      for expected_frame <- frames do
+        assert_receive {:can_frame, ^expected_frame}
+      end
+    end
+
+    test "specific subscriber doesn't receive frames via wildcard dispatch", %{registry: registry} do
+      # Only subscribe to specific ID
+      SocketCAN.subscribe(registry, 0x500)
+
+      test_frame = %Frame{
+        # Different ID
+        id: 0x600,
+        data: <<6, 6>>,
+        is_extended?: false,
+        frame_type: :data
+      }
+
+      # Dispatch to wildcard subscribers only
+      Registry.dispatch(registry, :all_frames, fn entries ->
+        for {pid, _value} <- entries do
+          send(pid, {:can_frame, test_frame})
+        end
+      end)
+
+      # Should not receive the frame
+      refute_receive {:can_frame, _}, 100
+    end
+
+    test "multiple wildcard subscribers all receive frames", %{registry: registry} do
+      # Create multiple processes subscribing to all frames
+      tasks =
+        for i <- 1..3 do
+          Task.async(fn ->
+            SocketCAN.subscribe(registry)
+            assert_receive {:can_frame, frame}
+            {i, frame}
+          end)
+        end
+
+      # Wait for subscriptions
+      Process.sleep(50)
+
+      test_frame = %Frame{
+        id: 0x777,
+        data: <<7, 7, 7>>,
+        is_extended?: false,
+        frame_type: :data
+      }
+
+      # Dispatch to wildcard subscribers
+      Registry.dispatch(registry, :all_frames, fn entries ->
+        for {pid, _value} <- entries do
+          send(pid, {:can_frame, test_frame})
+        end
+      end)
+
+      # All tasks should receive the frame
+      results = Task.await_many(tasks)
+      assert length(results) == 3
+
+      for {i, frame} <- results do
+        assert frame == test_frame
+        assert i in 1..3
+      end
+    end
+  end
+end

--- a/test/socket_can_test.exs
+++ b/test/socket_can_test.exs
@@ -2,7 +2,188 @@ defmodule SocketCANTest do
   use ExUnit.Case
   doctest SocketCAN
 
-  test "greets the world" do
-    assert SocketCAN.hello() == :world
+  describe "subscribe/2" do
+    test "subscribes to specific frame ID" do
+      registry_name = :"test_registry_#{System.unique_integer()}"
+      {:ok, _} = Registry.start_link(keys: :duplicate, name: registry_name)
+
+      # Subscribe to frame ID 0x123
+      assert :ok = SocketCAN.subscribe(registry_name, 0x123)
+
+      # Verify registration
+      current_pid = self()
+      assert [{^current_pid, nil}] = Registry.lookup(registry_name, 0x123)
+    end
+
+    test "allows multiple processes to subscribe to same frame ID" do
+      registry_name = :"test_registry_#{System.unique_integer()}"
+      {:ok, _} = Registry.start_link(keys: :duplicate, name: registry_name)
+
+      # Subscribe from current process
+      assert :ok = SocketCAN.subscribe(registry_name, 0x100)
+
+      # Spawn another process and subscribe
+      parent = self()
+
+      pid =
+        spawn(fn ->
+          SocketCAN.subscribe(registry_name, 0x100)
+          send(parent, :subscribed)
+
+          # Keep process alive for the test
+          receive do
+            :done -> :ok
+          end
+        end)
+
+      # Wait for subscription
+      assert_receive :subscribed
+
+      # Verify both processes are registered
+      subscribers = Registry.lookup(registry_name, 0x100)
+      assert length(subscribers) == 2
+
+      # Clean up
+      send(pid, :done)
+    end
+  end
+
+  describe "subscribe/1" do
+    test "subscribes to all frames" do
+      registry_name = :"test_registry_#{System.unique_integer()}"
+      {:ok, _} = Registry.start_link(keys: :duplicate, name: registry_name)
+
+      # Subscribe to all frames
+      assert :ok = SocketCAN.subscribe(registry_name)
+
+      # Verify registration under :all_frames key
+      current_pid = self()
+      assert [{^current_pid, nil}] = Registry.lookup(registry_name, :all_frames)
+    end
+
+    test "allows subscribing to both all frames and specific IDs" do
+      registry_name = :"test_registry_#{System.unique_integer()}"
+      {:ok, _} = Registry.start_link(keys: :duplicate, name: registry_name)
+
+      # Subscribe to all frames
+      assert :ok = SocketCAN.subscribe(registry_name)
+
+      # Also subscribe to specific frame
+      assert :ok = SocketCAN.subscribe(registry_name, 0x200)
+
+      # Verify both registrations
+      current_pid = self()
+      assert [{^current_pid, nil}] = Registry.lookup(registry_name, :all_frames)
+      assert [{^current_pid, nil}] = Registry.lookup(registry_name, 0x200)
+    end
+  end
+
+  describe "frame dispatching" do
+    test "wildcard subscribers receive all frames" do
+      # This test simulates what the Reader does
+      registry_name = :"test_registry_#{System.unique_integer()}"
+      {:ok, _} = Registry.start_link(keys: :duplicate, name: registry_name)
+
+      # Subscribe to all frames
+      SocketCAN.subscribe(registry_name)
+
+      # Simulate frame dispatch (what Reader does)
+      test_frame = %SocketCAN.Frame{
+        id: 0x123,
+        data: <<1, 2, 3, 4>>,
+        is_extended?: false,
+        frame_type: :data
+      }
+
+      # Dispatch to wildcard subscribers
+      Registry.dispatch(registry_name, :all_frames, fn entries ->
+        for {pid, _value} <- entries do
+          send(pid, {:can_frame, test_frame})
+        end
+      end)
+
+      # Verify frame received
+      assert_receive {:can_frame, ^test_frame}
+    end
+
+    test "specific subscribers only receive matching frames" do
+      registry_name = :"test_registry_#{System.unique_integer()}"
+      {:ok, _} = Registry.start_link(keys: :duplicate, name: registry_name)
+
+      # Subscribe to specific ID
+      SocketCAN.subscribe(registry_name, 0x100)
+
+      # Simulate dispatching different frame IDs
+      frame_100 = %SocketCAN.Frame{id: 0x100, data: <<1>>, is_extended?: false, frame_type: :data}
+      frame_200 = %SocketCAN.Frame{id: 0x200, data: <<2>>, is_extended?: false, frame_type: :data}
+
+      # Dispatch frame with ID 0x100
+      Registry.dispatch(registry_name, 0x100, fn entries ->
+        for {pid, _value} <- entries do
+          send(pid, {:can_frame, frame_100})
+        end
+      end)
+
+      # Dispatch frame with ID 0x200 (should not be received)
+      Registry.dispatch(registry_name, 0x200, fn entries ->
+        for {pid, _value} <- entries do
+          send(pid, {:can_frame, frame_200})
+        end
+      end)
+
+      # Should only receive frame_100
+      assert_receive {:can_frame, ^frame_100}
+      refute_receive {:can_frame, ^frame_200}, 100
+    end
+
+    test "wildcard and specific subscribers both receive frames" do
+      registry_name = :"test_registry_#{System.unique_integer()}"
+      {:ok, _} = Registry.start_link(keys: :duplicate, name: registry_name)
+
+      # Process 1: Subscribe to all frames
+      task1 =
+        Task.async(fn ->
+          SocketCAN.subscribe(registry_name)
+          assert_receive {:can_frame, frame}
+          {:wildcard, frame}
+        end)
+
+      # Process 2: Subscribe to specific ID
+      task2 =
+        Task.async(fn ->
+          SocketCAN.subscribe(registry_name, 0x300)
+          assert_receive {:can_frame, frame}
+          {:specific, frame}
+        end)
+
+      # Give tasks time to subscribe
+      Process.sleep(50)
+
+      # Simulate frame dispatch (as Reader would do)
+      test_frame = %SocketCAN.Frame{
+        id: 0x300,
+        data: <<3, 3, 3>>,
+        is_extended?: false,
+        frame_type: :data
+      }
+
+      # Dispatch to specific ID subscribers
+      Registry.dispatch(registry_name, 0x300, fn entries ->
+        for {pid, _value} <- entries do
+          send(pid, {:can_frame, test_frame})
+        end
+      end)
+
+      # Dispatch to wildcard subscribers
+      Registry.dispatch(registry_name, :all_frames, fn entries ->
+        for {pid, _value} <- entries do
+          send(pid, {:can_frame, test_frame})
+        end
+      end)
+
+      # Both tasks should receive the frame
+      assert {:wildcard, ^test_frame} = Task.await(task1)
+      assert {:specific, ^test_frame} = Task.await(task2)
+    end
   end
 end


### PR DESCRIPTION
- Add subscribe/1 function to receive all CAN frames
- Update Reader to dispatch frames to wildcard subscribers
- Add comprehensive test coverage for subscription system
- Update .gitignore with project-specific exclusions