### PR TITLE
Fix intermittent test failure in WriterTest

### DIFF
--- a/test/socket_can/writer_test.exs
+++ b/test/socket_can/writer_test.exs
@@ -12,8 +12,14 @@ defmodule SocketCAN.WriterTest do
     } end, name: :mock_socket_state)
     
     on_exit(fn -> 
-      if Process.whereis(:mock_socket_state) do
-        Agent.stop(:mock_socket_state)
+      if pid = Process.whereis(:mock_socket_state) do
+        if Process.alive?(pid) do
+          try do
+            Agent.stop(:mock_socket_state, :normal, 100)
+          catch
+            :exit, _ -> :ok
+          end
+        end
       end
     end)
     


### PR DESCRIPTION
The test teardown had a race condition where the mock_socket_state process could terminate between checking its existence and attempting to stop it. This caused Agent.stop/1 to fail with "no process" errors.

Fixed by:
- Capturing PID first to avoid TOCTOU issues
- Checking if process is alive before stopping
- Wrapping stop call in try/catch for graceful error handling
- Adding timeout to prevent hanging